### PR TITLE
fix typo on auto_log/autolog.py changing drivier to driver

### DIFF
--- a/auto_log/autolog.py
+++ b/auto_log/autolog.py
@@ -221,7 +221,7 @@ class AutoLogger(RunConfig):
         self.logger.info(
             f"{identifier} CUDNN_version: {envs['cudnn_version']}")
         self.logger.info(
-            f"{identifier} drivier_version: {envs['nvidia_driver_version']}")
+            f"{identifier} driver_version: {envs['nvidia_driver_version']}")
         self.logger.info(
             "---------------------- Paddle info ----------------------")
         self.logger.info(f"{identifier} paddle_version: {self.paddle_version}")


### PR DESCRIPTION
I was using the paddleseg lib at work and found this typo on the log generated by autolog and i thought it would be a simple contribution to the code,

I hope it fits well the contribution rules!