### PR TITLE
Fix: add include

### DIFF
--- a/auto_log/autolog.h
+++ b/auto_log/autolog.h
@@ -20,6 +20,7 @@
 #include <ostream>
 #include <stdlib.h>
 #include <vector>
+#include <numeric>
 #include <glog/logging.h>
 
 


### PR DESCRIPTION
# Issue:

Compile Project raise error: 

```
g++.exe .../extern_autolog-src/auto_log/autolog.h: In member function 'void AutoLogger::report()':
.../extern_autolog-src/auto_log/autolog.h:66:27: error: 'accumulate' is not a member of 'std'; did you mean 'cv::accumulate'?
   66 |                   << std::accumulate(this->time_info_.begin(), this->time_info_.end(), 0);
      |                           ^~~~~~~~~~
...
```

# Deps：

**Platform:** Win10

**Compiler:** MinGW‑w64 11.0 (GCC 11.x), C++17

**Compiler Tools:** CMake 3.28.1 + Ninja 1.11.1
